### PR TITLE
function check to work with composer

### DIFF
--- a/wpe-cache-flush.php
+++ b/wpe-cache-flush.php
@@ -23,35 +23,36 @@ function get_flush_token() {
 
 	return apply_filters( __NAMESPACE__ . '/wpe_cache_flush_token', false );
 }
+if (function_exists('add_action')) {
+	add_action( 'init', function () {
 
-add_action( 'init', function () {
+		$key = 'wpe-cache-flush';
 
-	$key = 'wpe-cache-flush';
+		if ( empty( $_GET[ $key ] ) ) {
+			return;
+		}
 
-	if ( empty( $_GET[ $key ] ) ) {
-		return;
-	}
+		$flush_token = get_flush_token();
 
-	$flush_token = get_flush_token();
+		if ( false === $flush_token ) {
+			return;
+		}
 
-	if ( false === $flush_token ) {
-		return;
-	}
+		if ( $flush_token !== $_GET[ $key ] ) {
+			return;
+		}
 
-	if ( $flush_token !== $_GET[ $key ] ) {
-		return;
-	}
+		$error = cache_flush();
 
-	$error = cache_flush();
+		header( "Content-Type: text/plain" );
+		header( "X-WPE-Host: " . gethostname() . " " . $_SERVER['SERVER_ADDR'] );
 
-	header( "Content-Type: text/plain" );
-	header( "X-WPE-Host: " . gethostname() . " " . $_SERVER['SERVER_ADDR'] );
+		echo "All Caches were purged!";
+		echo $error;
 
-	echo "All Caches were purged!";
-	echo $error;
-
-	exit( 0 );
-} );
+		exit( 0 );
+	} );
+}
 
 /**
  * Allow cache flushing to be called independently of web hook


### PR DESCRIPTION
When running composer install/update, a fatal error is thrown: `PHP Fatal error:  Uncaught Error: Call to undefined function A7\WPE_Cache_Flush\add_action()`.

This can be fixed by checking for the existence of `add_action`.